### PR TITLE
remove non domain

### DIFF
--- a/domains.csv
+++ b/domains.csv
@@ -2,27 +2,19 @@ ANLAZ,Anlagezustand,System Condition
 ARBPL,Arbeitsplatz,Work Centre
 AUART,Auftragsart,Sales order type
 BUKRS,Buchungkreis,Company code
-DMBTR,Deutschmarkbetrag,Amount in local currency
 EBELN,Einkaufsbelegnummer,Purchasing document number
 EBELP,Einkaufsbelegposition,Purchasing document item
 EQART,Art des technishen Objekts,Type of technical objects
 EQUNR,Equipmentnummer,Equipment Number
 FLDGP,Feldgruppe zur Gruppierung von einzelnen Feldern,Field group for grouping individual fields
-FLMNG,Fehlmenge der Komponente im Auftrag,Shortfall Quantity of Component in Order
 GROES,Groesse bzw Abmessung,Size or Dimension
 ILART,Instandhaltungsleistungsart,Maintenance Activity Type
 KNTNR,Knotennummer,Node Number
 KUNNR,Kundennummer,Customer number
-LOEKZ,Loeschkennzeichen,Deletion flag
-LOSGR,Planlosgrösse,Planned lot size
 MAHNT,Mahnungstagen,Dunning days
 MANDT,Mandant,Client
 MATKL,Materialklasse,Material class
-MATKZ,Materialzuordnung,Material Allocation
-PLNME,Planmengeneinheit,Task List Unit of Measure
-PLNTX,Beschreibung des Plantypen,Description of the Task List Type
 SHKZG,Soll/Haben Kennzeichnung,Debit/credit indicator
-TXTKZ,Langtext vorhanden,Long Text Exists
 UZEIT,Uhrzeit,Time
 VBELN,Verkaufsbelegnummer,Sales document number
 VKORG,Verkaufsorganization,Sales organisaion


### PR DESCRIPTION
Remove Non Domains (most mine because i was searching for DTEL)
![image](https://user-images.githubusercontent.com/13335743/159456202-4522a7e7-8537-4e36-aa2e-87e45d251d95.png)

Fix SQL Select (with correct object type `DOMA`)

```sql
SELECT ( tadir~obj_name && ',' && doma_de~ddtext && ',' && doma_en~ddtext ) AS string_csv,
  tadir~object
, doma_en~ddtext AS english
, doma_de~ddtext AS german
, tadir~obj_name
FROM tadir
LEFT OUTER JOIN dd01t AS doma_en " domain descriptions
  ON doma_en~ddlanguage = 'E'
  AND doma_en~domname = tadir~obj_name
LEFT OUTER JOIN dd01t AS doma_de " domain descriptions
  ON doma_de~ddlanguage = 'D'
  AND doma_de~domname = tadir~obj_name
WHERE   srcsystem = 'SAP'
  AND  author  = 'SAP'
  AND  cproject  = ' S'
  AND object = 'DOMA'
  AND length( obj_name ) = 5
  AND tadir~versid  = '1.0'
*  AND tadir~devclass = 'CP'
INTO TABLE @DATA(test)
  .
```